### PR TITLE
remove 2 decimal place default for Numeric/Float

### DIFF
--- a/wtforms_sqlalchemy/orm.py
+++ b/wtforms_sqlalchemy/orm.py
@@ -187,9 +187,8 @@ class ModelConverter(ModelConverterBase):
 
     @converts('Numeric', 'Float')
     def handle_decimal_types(self, column, field_args, **extra):
-        places = getattr(column.type, 'scale', 2)
-        if places is not None:
-            field_args['places'] = places
+        # override default decimal places limit, use database defaults instead
+        field_args.setdefault('places', None)
         return f.DecimalField(**field_args)
 
     @converts('databases.mysql.MSYear', 'dialects.mysql.base.YEAR')


### PR DESCRIPTION
It's common for users to use Float for GPS coordinates, and having a default of 2 decimal places isn't desirable.

This pull request changes the default to unlimited decimal places. And, instead relies on SQLAlchemy or the database to set limits on the displayed number of decimal places.

More details available here: https://github.com/flask-admin/flask-admin/pull/1155