### PR TITLE
remove copied deprecation warning

### DIFF
--- a/wtforms_sqlalchemy/orm.py
+++ b/wtforms_sqlalchemy/orm.py
@@ -4,7 +4,6 @@ Tools for generating forms based on SQLAlchemy models.
 from __future__ import unicode_literals
 
 import inspect
-import warnings
 
 from wtforms import fields as f
 from wtforms import validators
@@ -13,12 +12,6 @@ from .fields import QuerySelectField, QuerySelectMultipleField
 
 __all__ = (
     'model_fields', 'model_form',
-)
-
-
-warnings.warn(
-    'wtforms.ext.sqlalchemy.orm is deprecated, and will be removed in WTForms 3.0.',
-    DeprecationWarning
 )
 
 


### PR DESCRIPTION
This warning isn't relevant for the code moved to this repo: `wtforms.ext.sqlalchemy.orm is deprecated, and will be removed in WTForms 3.0.`

This pull request removes the warning.