### PR TITLE
prevent original shared field_arg values from getting modified

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -12,7 +12,7 @@ from wtforms.compat import text_type, iteritems
 from wtforms_sqlalchemy.fields import QuerySelectField, QuerySelectMultipleField
 from wtforms import Form, fields
 from wtforms_sqlalchemy.orm import model_form, ModelConversionError, ModelConverter
-from wtforms.validators import Optional, Required
+from wtforms.validators import Optional, Required, Regexp
 from .common import DummyPostData, contains_validator
 
 
@@ -237,6 +237,14 @@ class ModelFormTest(TestCase):
         student_form = model_form(self.Student, self.sess)()
         assert contains_validator(student_form.dob, Optional)
         assert contains_validator(student_form.full_name, Required)
+
+    def test_field_args(self):
+        shared = {'full_name': {'validators': [Regexp('test')]}}
+        student_form = model_form(self.Student, self.sess, field_args=shared)()
+        assert contains_validator(student_form.full_name, Regexp)
+
+        # original shared field_args should not be modified
+        assert len(shared['full_name']['validators']) == 1
 
     def test_include_pk(self):
         form_class = model_form(self.Student, self.sess, exclude_pk=False)

--- a/wtforms_sqlalchemy/orm.py
+++ b/wtforms_sqlalchemy/orm.py
@@ -56,6 +56,13 @@ class ModelConverterBase(object):
             'default': None,
         }
 
+        if field_args:
+            kwargs.update(field_args)
+
+        if kwargs['validators']:
+            # Copy to prevent modifying nested mutable values of the original
+            kwargs['validators'] = list(kwargs['validators'])
+
         converter = None
         column = None
         types = None
@@ -122,9 +129,6 @@ class ModelConverterBase(object):
             })
 
             converter = self.converters[prop.direction.name]
-
-        if field_args:
-            kwargs.update(field_args)
 
         return converter(
             model=model,


### PR DESCRIPTION
This pull request prevents a bug that can occur when an user overrides field_args with their own validators and shares those field_args across multiple forms. Wtforms-sqlalchemy will modify the original shared field_args, which can cause duplicate validators.

See this pull request for more details: https://github.com/coleifer/wtf-peewee/pull/30