### PR TITLE
update identity_key results unpacking

### DIFF
--- a/wtforms_sqlalchemy/fields.py
+++ b/wtforms_sqlalchemy/fields.py
@@ -186,5 +186,5 @@ class QuerySelectMultipleField(QuerySelectField):
 
 
 def get_pk_from_identity(obj):
-    cls, key = identity_key(instance=obj)
+    cls, key = identity_key(instance=obj)[:2]
     return ':'.join(text_type(x) for x in key)


### PR DESCRIPTION
sqlalchemy now returns a third member to the identity_key result (since 1.2.0, commit 50d9f1687), we must ignore it.