### PR TITLE
QuerySelectField.query allowing no results []

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -97,6 +97,16 @@ class QuerySelectFieldTest(TestBase):
         assert not form.validate()
         self.assertEqual(form.a.errors, ['Not a valid choice'])
 
+        # Test query with no results
+        form = F()
+        form.a.query = (
+            sess.query(self.Test)
+            .filter(self.Test.id == 1, self.Test.id != 1)
+            .all()
+        )
+        self.assertEqual(form.a(), [])
+
+
     def test_with_query_factory(self):
         sess = self.Session()
         self._fill(sess)
@@ -133,6 +143,15 @@ class QuerySelectFieldTest(TestBase):
         self.assertEqual(form.a.errors, ['Not a valid choice'])
         self.assertEqual(form.b.errors, [])
         self.assertEqual(form.b.data, None)
+
+        # Test query with no results
+        form = F()
+        form.a.query = (
+            sess.query(self.Test)
+            .filter(self.Test.id == 1, self.Test.id != 1)
+            .all()
+        )
+        self.assertEqual(form.a(), [])
 
 
 class QuerySelectMultipleFieldTest(TestBase):

--- a/wtforms_sqlalchemy/fields.py
+++ b/wtforms_sqlalchemy/fields.py
@@ -96,7 +96,10 @@ class QuerySelectField(SelectFieldBase):
 
     def _get_object_list(self):
         if self._object_list is None:
-            query = self.query or self.query_factory()
+            query = (
+                self.query if self.query is not None
+                else self.query_factory()
+            )
             get_pk = self.get_pk
             self._object_list = list((text_type(get_pk(obj)), obj) for obj in query)
         return self._object_list


### PR DESCRIPTION
There was a bug when deciding to use either query or query_factory in QuerySelectField. Queries that returned no value where silently ignored in favor of query_factory. This has been fixed. 

I've detected this issue using wtforms-sqlalchemy, which uses a similar QuerySelectField class and derived classes.

This solves issue #14 