### PR TITLE
Explicitly check if db_session is None in converter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,25 @@
 language: python
 
 python:
-  - 2.6
   - 2.7
-  - 3.3
-  - 3.4
+  - 3.5
+  - 3.6
 
 env:
   global:
-    - WTFORMS="<2.1"
+    - WTFORMS="<3"
   matrix:
-    - SQLALCHEMY=0.7.10
-    - SQLALCHEMY=0.8.6
-    - SQLALCHEMY=0.8.6 WTFORMS="==1.0.5"
-    - SQLALCHEMY=0.9.6
-    - SQLALCHEMY=0.9.8 WTFORMS="==1.0.5"
+    - SQLALCHEMY="==0.7.10"
+    - SQLALCHEMY="~=0.8.6"
+    - SQLALCHEMY="==0.8.6" WTFORMS="==1.0.5"
+    - SQLALCHEMY="~=0.9.6"
+    - SQLALCHEMY="==0.9.8" WTFORMS="==1.0.5"
+    - SQLALCHEMY=""
 
 
 # command to install dependencies
 install:
-  - "pip install WTForms$WTFORMS SQLAlchemy==$SQLALCHEMY"
+  - "pip install WTForms$WTFORMS SQLAlchemy$SQLALCHEMY"
   - "pip install ."
   - "pip install -r tests/requirements.txt"
 

--- a/wtforms_sqlalchemy/orm.py
+++ b/wtforms_sqlalchemy/orm.py
@@ -120,7 +120,7 @@ class ModelConverterBase(object):
             converter = self.get_converter(column)
         else:
             # We have a property with a direction.
-            if not db_session:
+            if db_session is None:
                 raise ModelConversionError("Cannot convert field %s, need DB session." % prop.key)
 
             foreign_model = prop.mapper.class_

--- a/wtforms_sqlalchemy/orm.py
+++ b/wtforms_sqlalchemy/orm.py
@@ -195,7 +195,7 @@ class ModelConverter(ModelConverterBase):
         field_args.setdefault('places', None)
         return wtforms_fields.DecimalField(**field_args)
 
-    @converts('dialects.mysql.base.YEAR')
+    @converts('dialects.mysql.types.YEAR', 'dialects.mysql.base.YEAR')
     def conv_MSYear(self, field_args, **extra):
         field_args['validators'].append(validators.NumberRange(min=1901, max=2155))
         return wtforms_fields.StringField(**field_args)

--- a/wtforms_sqlalchemy/orm.py
+++ b/wtforms_sqlalchemy/orm.py
@@ -67,7 +67,7 @@ class ModelConverterBase(object):
             if col_type.__name__ in self.converters:
                 return self.converters[col_type.__name__]
 
-        raise ModelConversionError('Could not find field converter for %s (%r).' % (prop.key, types[0]))
+        raise ModelConversionError('Could not find field converter for %s (%r).' % (column.key, types[0]))
 
     def convert(self, model, mapper, prop, field_args, db_session=None):
         if not hasattr(prop, 'columns') and not hasattr(prop, 'direction'):


### PR DESCRIPTION
This allows the use of a Werkzeug LocalProxy for handling sessions tied to requests, for example. An unbound LocalProxy is falsey, and the session LocalProxy is unbound during application start up, but the session will exist by the time a form is actually built.

I also fixed some errors in the tests while I was at it.