### PR TITLE
Upate not-nullable to apply .InputRequired instead of obsolete .Required

### DIFF
--- a/wtforms_sqlalchemy/orm.py
+++ b/wtforms_sqlalchemy/orm.py
@@ -126,7 +126,7 @@ class ModelConverterBase:
             if column.nullable:
                 kwargs["validators"].append(validators.Optional())
             else:
-                kwargs["validators"].append(validators.Required())
+                kwargs["validators"].append(validators.InputRequired())
 
             converter = self.get_converter(column)
         else:


### PR DESCRIPTION
WTForms is obsoleting .Required in favour of the more descriptive .InputRequired

This change updates wtforms-sqlalchemy to match.