### PR TITLE
Allow to override the default blank value "__None"

### DIFF
--- a/docs/wtforms_sqlalchemy.rst
+++ b/docs/wtforms_sqlalchemy.rst
@@ -33,7 +33,7 @@ your forms.
         form.blog.query = Blog.query.filter(Blog.author == request.user).order_by(Blog.name)
 
 
-.. autoclass:: QuerySelectField(default field args, query_factory=None, get_pk=None, get_label=None, allow_blank=False, blank_text=u'')
+.. autoclass:: QuerySelectField(default field args, query_factory=None, get_pk=None, get_label=None, allow_blank=False, blank_text=u'', blank_value=u'__None')
 
 .. autoclass:: QuerySelectMultipleField(default field args, query_factory=None, get_pk=None, get_label=None)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -141,6 +141,13 @@ class QuerySelectFieldTest(TestBase):
                 query_factory=lambda: sess.query(self.PKTest),
                 widget=LazySelect(),
             )
+            c = QuerySelectField(
+                allow_blank=True,
+                blank_text="",
+                blank_value="",
+                query_factory=lambda: sess.query(self.PKTest),
+                widget=LazySelect(),
+            )
 
         form = F()
         self.assertEqual(form.a.data, None)
@@ -154,9 +161,14 @@ class QuerySelectFieldTest(TestBase):
                 ("hello2", "banana", False),
             ],
         )
+        self.assertEqual(form.c.data, None)
+        self.assertEqual(
+            form.c(),
+            [("", "", True), ("hello1", "apple", False), ("hello2", "banana", False)],
+        )
         self.assertFalse(form.validate())
 
-        form = F(DummyPostData(a=["1"], b=["hello2"]))
+        form = F(DummyPostData(a=["1"], b=["hello2"], c=[""]))
         self.assertEqual(form.a.data.id, 1)
         self.assertEqual(form.a(), [("1", "apple", True), ("2", "banana", False)])
         self.assertEqual(form.b.data.baz, "banana")
@@ -167,6 +179,11 @@ class QuerySelectFieldTest(TestBase):
                 ("hello1", "apple", False),
                 ("hello2", "banana", True),
             ],
+        )
+        self.assertEqual(form.c.data, None)
+        self.assertEqual(
+            form.c(),
+            [("", "", True), ("hello1", "apple", False), ("hello2", "banana", False)],
         )
         self.assertTrue(form.validate())
 

--- a/wtforms_sqlalchemy/fields.py
+++ b/wtforms_sqlalchemy/fields.py
@@ -51,7 +51,8 @@ class QuerySelectField(SelectFieldBase):
     If `allow_blank` is set to `True`, then a blank choice will be added to the
     top of the list. Selecting this choice will result in the `data` property
     being `None`. The label for this blank choice can be set by specifying the
-    `blank_text` parameter.
+    `blank_text` parameter. The value for this blank choice can be set by
+    specifying the `blank_value` parameter (default: `__None`).
     """
 
     widget = widgets.Select()
@@ -65,6 +66,7 @@ class QuerySelectField(SelectFieldBase):
         get_label=None,
         allow_blank=False,
         blank_text="",
+        blank_value="__None",
         **kwargs
     ):
         super().__init__(label, validators, **kwargs)
@@ -88,6 +90,7 @@ class QuerySelectField(SelectFieldBase):
 
         self.allow_blank = allow_blank
         self.blank_text = blank_text
+        self.blank_value = blank_value
         self.query = None
         self._object_list = None
 
@@ -114,14 +117,14 @@ class QuerySelectField(SelectFieldBase):
 
     def iter_choices(self):
         if self.allow_blank:
-            yield ("__None", self.blank_text, self.data is None)
+            yield (self.blank_value, self.blank_text, self.data is None)
 
         for pk, obj in self._get_object_list():
             yield (pk, self.get_label(obj), obj == self.data)
 
     def process_formdata(self, valuelist):
         if valuelist:
-            if self.allow_blank and valuelist[0] == "__None":
+            if self.allow_blank and valuelist[0] == self.blank_value:
                 self.data = None
             else:
                 self._data = None


### PR DESCRIPTION
The sentinel value to detect a blank option is currently `__None`. This is unfortunately incompatible with [select2](https://github.com/select2/select2). select2 expects a blank field to have an empty value. I assume that there are more tools out there with this requirement so I think it would be valuable if this use case was supported by wtforms-sqlalchemy.

This PR adds the keyword argument `blank_value` to `QuerySelectField` to make it configurable. It's still `__None` by default for backwards compatibility.

This is similar to PR #27 but configurable and with tests and documentation.