### PR TITLE
Fix typo (`wtalchemy`) in docs example code

### DIFF
--- a/wtforms_sqlalchemy/orm.py
+++ b/wtforms_sqlalchemy/orm.py
@@ -297,7 +297,7 @@ def model_form(
     """
     Create a wtforms Form for a given SQLAlchemy model class::
 
-        from wtalchemy.orm import model_form
+        from wtforms_sqlalchemy.orm import model_form
         from myapp.models import User
         UserForm = model_form(User)
 


### PR DESCRIPTION
`from wtalchemy import ...` -> `from wtforms_sqlalchemy import ...`