### PR TITLE
Add render_kw support (#40)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages = wtforms_sqlalchemy
 include_package_data = true
 python_requires = >= 3.8
 install_requires =
-  WTForms>=1.0.5
+  WTForms>=3.1
   SQLAlchemy>=0.7.10,<2
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages = wtforms_sqlalchemy
 include_package_data = true
 python_requires = >= 3.8
 install_requires =
-  WTForms>=1.0.5,<3.1
+  WTForms>=1.0.5
   SQLAlchemy>=0.7.10,<2
 
 [flake8]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -34,7 +34,8 @@ from .common import DummyPostData
 class LazySelect:
     def __call__(self, field, **kwargs):
         return list(
-            (val, str(label), selected, render_kw) for val, label, selected, render_kw in field.iter_choices()
+            (val, str(label), selected, render_kw)
+            for val, label, selected, render_kw in field.iter_choices()
         )
 
 
@@ -111,7 +112,9 @@ class QuerySelectFieldTest(TestBase):
         form.a.query = sess.query(self.Test)
         self.assertTrue(form.a.data is not None)
         self.assertEqual(form.a.data.id, 1)
-        self.assertEqual(form.a(), [("1", "apple", True, {}), ("2", "banana", False, {})])
+        self.assertEqual(
+            form.a(), [("1", "apple", True, {}), ("2", "banana", False, {})]
+        )
         self.assertTrue(form.validate())
 
         form = F(a=sess.query(self.Test).filter_by(name="banana").first())
@@ -144,7 +147,9 @@ class QuerySelectFieldTest(TestBase):
 
         form = F()
         self.assertEqual(form.a.data, None)
-        self.assertEqual(form.a(), [("1", "apple", False, {}), ("2", "banana", False, {})])
+        self.assertEqual(
+            form.a(), [("1", "apple", False, {}), ("2", "banana", False, {})]
+        )
         self.assertEqual(form.b.data, None)
         self.assertEqual(
             form.b(),
@@ -158,7 +163,9 @@ class QuerySelectFieldTest(TestBase):
 
         form = F(DummyPostData(a=["1"], b=["hello2"]))
         self.assertEqual(form.a.data.id, 1)
-        self.assertEqual(form.a(), [("1", "apple", True, {}), ("2", "banana", False, {})])
+        self.assertEqual(
+            form.a(), [("1", "apple", True, {}), ("2", "banana", False, {})]
+        )
         self.assertEqual(form.b.data.baz, "banana")
         self.assertEqual(
             form.b(),
@@ -174,11 +181,17 @@ class QuerySelectFieldTest(TestBase):
         sess.add(self.Test(id=3, name="meh"))
         sess.flush()
         sess.commit()
-        self.assertEqual(form.a(), [("1", "apple", True, {}), ("2", "banana", False, {})])
+        self.assertEqual(
+            form.a(), [("1", "apple", True, {}), ("2", "banana", False, {})]
+        )
         form.a._object_list = None
         self.assertEqual(
             form.a(),
-            [("1", "apple", True, {}), ("2", "banana", False, {}), ("3", "meh", False, {})],
+            [
+                ("1", "apple", True, {}),
+                ("2", "banana", False, {}),
+                ("3", "meh", False, {}),
+            ],
         )
 
         # Test bad data
@@ -217,14 +230,18 @@ class QuerySelectMultipleFieldTest(TestBase):
         form = self.F(DummyPostData(a=["1"]))
         form.a.query = self.sess.query(self.Test)
         self.assertEqual([1], [v.id for v in form.a.data])
-        self.assertEqual(form.a(), [("1", "apple", True, {}), ("2", "banana", False, {})])
+        self.assertEqual(
+            form.a(), [("1", "apple", True, {}), ("2", "banana", False, {})]
+        )
         self.assertTrue(form.validate())
 
     def test_multiple_values_without_query_factory(self):
         form = self.F(DummyPostData(a=["1", "2"]))
         form.a.query = self.sess.query(self.Test)
         self.assertEqual([1, 2], [v.id for v in form.a.data])
-        self.assertEqual(form.a(), [("1", "apple", True, {}), ("2", "banana", True, {})])
+        self.assertEqual(
+            form.a(), [("1", "apple", True, {}), ("2", "banana", True, {})]
+        )
         self.assertTrue(form.validate())
 
         form = self.F(DummyPostData(a=["1", "3"]))
@@ -245,7 +262,9 @@ class QuerySelectMultipleFieldTest(TestBase):
 
         form = F()
         self.assertEqual([v.id for v in form.a.data], [2])
-        self.assertEqual(form.a(), [("1", "apple", False, {}), ("2", "banana", True, {})])
+        self.assertEqual(
+            form.a(), [("1", "apple", False, {}), ("2", "banana", True, {})]
+        )
         self.assertTrue(form.validate())
 
 


### PR DESCRIPTION
WTForms choices iterators have recently changed to expect a tuple of 
4 elements.  This change provides a callable field `get_render_kw` which
is similar to `get_pk` and `get_label`.

Note: blank form values have no `obj` reference, so it doesn't make 
sense to call `get_render_kw` in that scope.  For now an empty dict
is returned, but maybe it should provide a `blank_render_kw` 
callable?  That's a bit of a design decision that's not up to me.

I've had a quick look at fixing up the unit tests to make them pass, but 
nothing substantial has been added to test the get_render_kw return
values.