### PR TITLE
Columns with a default value should not be required

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -457,11 +457,13 @@ class ModelFormColumnDefaultTest(TestCase):
     def test_column_default_callable(self):
         student_form = model_form(self.StudentDefaultScoreCallable, self.sess)()
         self.assertEqual(student_form._fields["score"].default, 5)
+        assert not contains_validator(student_form.score, InputRequired)
 
     def test_column_default_scalar(self):
         student_form = model_form(self.StudentDefaultScoreScalar, self.sess)()
         assert not isinstance(student_form._fields["score"].default, ColumnDefault)
         self.assertEqual(student_form._fields["score"].default, 10)
+        assert not contains_validator(student_form.score, InputRequired)
 
 
 class ModelFormTest2(TestCase):

--- a/wtforms_sqlalchemy/orm.py
+++ b/wtforms_sqlalchemy/orm.py
@@ -120,7 +120,7 @@ class ModelConverterBase:
 
             kwargs["default"] = default
 
-            if column.nullable:
+            if column.nullable or default is not None:
                 kwargs["validators"].append(validators.Optional())
             else:
                 kwargs["validators"].append(validators.InputRequired())


### PR DESCRIPTION
If a column has a default value, then make the input field optional when generating a form object from a model.

This enables the defaults in the table definition to allow for empty string in a text field and an unchecked checkbox to be submitted.

Closes #47